### PR TITLE
return metric averages

### DIFF
--- a/run_eval.py
+++ b/run_eval.py
@@ -30,11 +30,14 @@ class RunEval:
         self.created_by = os.getenv("CREATED_BY", "Github Action")
         self.run_status_url = 'https://api.coval.dev/eval/run'
         
-    def get_run_status_api(self, run_id):
+    def get_run_status_api(self, run_id, get_metrics=False):
         """
         This function gets the status of the run from the API.
         """
         config = {"run_id": run_id}
+        if (get_metrics):
+            config["type"] = "metrics"
+
         headers = {
             "Content-Type": "application/json",
             "x-api-key": self.api_key,
@@ -52,7 +55,7 @@ class RunEval:
                 print(f"Error Response Headers: {json.dumps(dict(e.response.headers), indent=2)}")
                 print(f"Error Response Body: {e.response.text}")
             return None
-
+        
     def _wait_for_run_to_complete(self, run_id, max_wait_time=600, check_interval=60):
         """
         This function waits for the run to complete by periodically checking its status.
@@ -103,6 +106,9 @@ class RunEval:
 
             # Wait for the job to finish
             self._wait_for_run_to_complete(run_id)
+            final_run_result = self.get_run_status_api(run_id, get_metrics=True)
+            averages = final_run_result.get('averages')
+            return averages
 
         except requests.exceptions.RequestException as e:
             print(f"Request Exception: {str(e)}")


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Enhance `run_eval.py` to return metric averages by updating `get_run_status_api` and `run` functions.
> 
>   - **Behavior**:
>     - `get_run_status_api` in `run_eval.py` now accepts `get_metrics` parameter to fetch metrics.
>     - `run` in `run_eval.py` retrieves and returns metric averages after run completion.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=coval-ai%2Fcoval-github-actions&utm_source=github&utm_medium=referral)<sup> for d2a374b0a6c074aba41ad934dc22d7ce0a484f76. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->